### PR TITLE
feat: Add Secrets Manger integration support

### DIFF
--- a/.github/workflows/deploy-cloudrun-it.yml
+++ b/.github/workflows/deploy-cloudrun-it.yml
@@ -100,6 +100,24 @@ jobs:
         SERVICE: ${{ steps.service.outputs.service }}
         SECRET_ENV: MY_SECRET=secret_value:latest
 
+    - name: Update service with mounted secret
+      id: deploy_2
+      uses: ./
+      with:
+        credentials: ${{ secrets.DEPLOY_CLOUDRUN_SA_KEY_JSON }}
+        image: gcr.io/cloudrun/hello
+        service: ${{ steps.service.outputs.service }}
+        secrets: /api/secrets/my-secret=secret_value:latest
+
+    - name: Integration Tests # Check that config isn't overwritten
+      run: npm run e2e-tests
+      env:
+        URL: ${{ steps.deploy_2.outputs.url }}
+        SERVICE: ${{ steps.service.outputs.service }}
+        SECRET_ENV: MY_SECRET=secret_value:latest
+        SECRET_VOLUMES: /api/secrets/my-secret=secret_value:latest
+        COUNT: 2
+
   yaml:
     name: with YAML metadata
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/deploy-cloudrun-it.yml
+++ b/.github/workflows/deploy-cloudrun-it.yml
@@ -368,7 +368,7 @@ jobs:
     name: Clean Up
     if: ${{ (github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name) && always() }}
     runs-on: ubuntu-latest
-    needs: [envvars, metadata, yaml, revision, name]
+    needs: [envvars, secret-manager, metadata, yaml, revision, name]
     steps:
     - uses: google-github-actions/setup-gcloud@master
       with:
@@ -382,5 +382,6 @@ jobs:
         gcloud run services delete run-full-yaml-$GITHUB_SHA --quiet
         gcloud run services delete run-yaml-$GITHUB_SHA --quiet
         gcloud run services delete run-envvars-$GITHUB_SHA --quiet
+        gcloud run services delete run-secret-manager-$GITHUB_SHA --quiet
         gcloud run services delete run-revision-name-$GITHUB_SHA --quiet
         gcloud run services delete test-service-name --quiet

--- a/.github/workflows/deploy-cloudrun-it.yml
+++ b/.github/workflows/deploy-cloudrun-it.yml
@@ -62,6 +62,44 @@ jobs:
         ENV: TEST_ENV=TEST_VAR,TEST_ENV2=TEST_VAR2
         COUNT: 2
 
+  secret-manager:
+    name: with Secret Manager
+    if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: service
+      run: echo ::set-output name=service::run-secret-manager-$GITHUB_SHA
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@master
+      with:
+        node-version: 12.x
+    - name: Build Javascript
+      run: |-
+        npm install
+        npm run build
+
+    - name: Create Service with Secret Manager
+      id: deploy_1
+      uses: ./
+      with:
+        credentials: ${{ secrets.DEPLOY_CLOUDRUN_SA_KEY_JSON }}
+        image: gcr.io/cloudrun/hello
+        service: ${{ steps.service.outputs.service }}
+        secrets: MY_SECRET=secret_value:latest
+
+    - name: Setup Authentication with gcloud
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        service_account_key: ${{ secrets.DEPLOY_CLOUDRUN_SA_KEY_B64 }}
+        export_default_credentials: true
+
+    - name: Integration Tests
+      run: npm run e2e-tests
+      env:
+        URL: ${{ steps.deploy_1.outputs.url }}
+        SERVICE: ${{ steps.service.outputs.service }}
+        SECRET_ENV: MY_SECRET=secret_value:latest
+
   yaml:
     name: with YAML metadata
     if: ${{ github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name }}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Cloud Run service. See the [Credentials](#credentials) below for more informatio
 | `region`| _optional_ | `us-central1` | Region in which the resource can be found. |
 | `credentials`| Required if not using a the `setup-gcloud` action with exported credentials. | | Service account key to use for authentication. This should be the JSON formatted private key which can be exported from the Cloud Console. The value can be raw or base64-encoded.  |
 | `env_vars`| _optional_ | | List of key-value pairs to set as environment variables in the format: `KEY1=VALUE1,KEY2=VALUE2`. **All existing environment variables will be retained**. |
+| `secrets`| _optional_ | | List of key-value pairs to set as either environment variables or mounted volumes in the format: `KEY1=secret-key-1:latest,/secrets/api/key=secret-key-2:latest`. The secrets will be fetched from the Secret Manager. **All existing environment secrets or volumes will be retained**. |
 | `metadata`| _optional_ | | YAML service description for the Cloud Run service (`service` and `image` inputs will override YAML). See [Metadata customizations](#metadata-customizations) for more information. **Existing configuration will be retained besides container entrypoint and arguments**. |
 | `project_id`| _optional_ | | ID of the Google Cloud project. If provided, this will override the project configured by `setup-gcloud`. |
 | `source` | _optional_ | | Deploy from source by specifying the source directory. The role `Cloud Build Service Account` is required. |

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,15 @@ inputs:
   env_vars:
     description: |-
       List of key-value pairs to set as environment variables in the format:
-      KEY1=VALUE1,KEY2=VALUE2. All existing environment variables will be
-      removed first.
+      KEY1=VALUE1,KEY2=VALUE2. Existing environment variables will be retained.
+    required: false
+
+  secrets:
+    description: |-
+      List of key-value pairs to set as either environment variables or mounted
+      volumes in the format:
+      KEY1=secret-key-1:latest,/secrets/api/key=secret-key-2:latest. Existing
+      secrets will be retained.
     required: false
 
   metadata:

--- a/src/deploy-cloudrun.ts
+++ b/src/deploy-cloudrun.ts
@@ -40,6 +40,7 @@ export async function run(): Promise<void> {
     let gcloudVersion = core.getInput('gcloud_version');
     // Flags
     const envVars = core.getInput('env_vars'); // String of env vars KEY=VALUE,...
+    const secrets = core.getInput('secrets'); // String of secrets KEY=VALUE,...
     const region = core.getInput('region') || 'us-central1';
     const source = core.getInput('source'); // Source directory
     const suffix = core.getInput('suffix');
@@ -97,9 +98,9 @@ export async function run(): Promise<void> {
       installBeta = true;
     } else if (metadata) {
       // Deploy service from metadata
-      if (image || name || envVars) {
+      if (image || name || envVars || secrets) {
         core.warning(
-          'Metadata YAML provided: ignoring `image`, `service`, and `env_vars` inputs.',
+          'Metadata YAML provided: ignoring `image`, `service`, `env_vars` and `secrets` inputs.',
         );
       }
       cmd = [
@@ -132,6 +133,7 @@ export async function run(): Promise<void> {
     if (!metadata) {
       // Set optional flags from inputs
       if (envVars) cmd.push('--update-env-vars', envVars);
+      if (secrets) cmd.push('--update-secrets', secrets);
       if (tag) {
         cmd.push('--tag', tag);
         cmd.unshift('beta');

--- a/src/deploy-cloudrun.ts
+++ b/src/deploy-cloudrun.ts
@@ -133,14 +133,17 @@ export async function run(): Promise<void> {
     if (!metadata) {
       // Set optional flags from inputs
       if (envVars) cmd.push('--update-env-vars', envVars);
-      if (secrets) cmd.push('--update-secrets', secrets);
+      if (secrets) {
+        cmd.push('--update-secrets', secrets);
+        installBeta = true;
+      }
       if (tag) {
         cmd.push('--tag', tag);
-        cmd.unshift('beta');
         installBeta = true;
       }
       if (suffix) cmd.push('--revision-suffix', suffix);
       if (noTraffic) cmd.push('--no-traffic');
+      if (installBeta) cmd.unshift('beta');
     }
     // Add optional flags
     if (flags) {

--- a/src/deploy-cloudrun.ts
+++ b/src/deploy-cloudrun.ts
@@ -67,7 +67,6 @@ export async function run(): Promise<void> {
     if (revTraffic || tagTraffic) {
       // Update traffic
       cmd = [
-        'beta',
         'run',
         'services',
         'update-traffic',
@@ -83,7 +82,6 @@ export async function run(): Promise<void> {
     } else if (source) {
       // Deploy service from source
       cmd = [
-        'beta',
         'run',
         'deploy',
         name,
@@ -104,7 +102,6 @@ export async function run(): Promise<void> {
         );
       }
       cmd = [
-        'beta',
         'run',
         'services',
         'replace',
@@ -143,7 +140,6 @@ export async function run(): Promise<void> {
       }
       if (suffix) cmd.push('--revision-suffix', suffix);
       if (noTraffic) cmd.push('--no-traffic');
-      if (installBeta) cmd.unshift('beta');
     }
     // Add optional flags
     if (flags) {
@@ -184,8 +180,11 @@ export async function run(): Promise<void> {
         'No project Id provided. Ensure you have set either the project_id or credentials fields.',
       );
 
-    // Install beta components if needed
-    if (installBeta) await setupGcloud.installComponent('beta');
+    // Install beta components if needed and prepend the beta command
+    if (installBeta) {
+      await setupGcloud.installComponent('beta');
+      cmd.unshift('beta');
+    }
 
     const toolCommand = setupGcloud.getToolCommand();
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -33,6 +33,7 @@ describe('E2E tests', function () {
     LABELS,
     ENV,
     SECRET_ENV,
+    SECRET_VOLUMES,
     SERVICE,
     COUNT,
     REVISION,
@@ -122,6 +123,24 @@ describe('E2E tests', function () {
       actual.forEach((secretEnvVar: run_v1.Schema$EnvVar) => {
         const found = expected.find((expectedSecretEnvVar) =>
           _.isEqual(secretEnvVar.name, expectedSecretEnvVar.name),
+        );
+        expect(found).to.not.equal(undefined);
+      });
+    }
+  });
+
+  it('has the correct secret volumes', function () {
+    if (SECRET_VOLUMES && service) {
+      const expected = parseEnvVars(SECRET_VOLUMES);
+      const containers: run_v1.Schema$Container[] = _.get(
+        service,
+        'spec.template.spec.containers',
+      );
+      const actual = containers[0]?.volumeMounts;
+      expect(actual).to.have.lengthOf(expected.length);
+      actual?.forEach((secretVolume: run_v1.Schema$VolumeMount) => {
+        const found = expected.find((expectedSecretVolume) =>
+          _.isEqual(secretVolume.mountPath, expectedSecretVolume.name),
         );
         expect(found).to.not.equal(undefined);
       });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -32,6 +32,7 @@ describe('E2E tests', function () {
     ANNOTATIONS,
     LABELS,
     ENV,
+    SECRET_ENV,
     SERVICE,
     COUNT,
     REVISION,
@@ -106,6 +107,21 @@ describe('E2E tests', function () {
       actual.forEach((envVar: run_v1.Schema$EnvVar) => {
         const found = expected.find((expectedEnvVar) =>
           _.isEqual(envVar, expectedEnvVar),
+        );
+        expect(found).to.not.equal(undefined);
+      });
+    }
+  });
+
+  it('has the correct secret vars', function () {
+    if (SECRET_ENV && service) {
+      const expected = parseEnvVars(SECRET_ENV);
+      const containers = _.get(service, 'spec.template.spec.containers');
+      const actual = containers[0]?.env;
+      expect(actual).to.have.lengthOf(expected.length);
+      actual.forEach((secretEnvVar: run_v1.Schema$EnvVar) => {
+        const found = expected.find((expectedSecretEnvVar) =>
+          _.isEqual(secretEnvVar.name, expectedSecretEnvVar.name),
         );
         expect(found).to.not.equal(undefined);
       });


### PR DESCRIPTION
Adds support for new secret referencing/mounting.

By adding the following line

```yaml
- secrets: LOCAL_ENV_NAME=secret-name:[revision|latest],...
```

 to the `with` section in the GitHub action, it will fetch secrets with the name `secret-name` with the version (or `latest`, depending on the suffix) and add it either as environment variable or mount it as a file.

Adding multiple entries after the comma will add more secrets.

I wanted to add end-to-end testing with the [Secret Manager action](https://github.com/google-github-actions/get-secretmanager-secrets), but it turned out it could only read secrets, and not add them. I can look into adding tests through the CLI instead with something like the below, but would appreciate feedback on the approach before doing so 🙂 

```sh
printf "bar" | gcloud secrets create foo --data-file=-
```

Closes #63 