### PR TITLE
fix: Update to PR target

### DIFF
--- a/.github/workflows/deploy-cloudrun-credentials-it.yml
+++ b/.github/workflows/deploy-cloudrun-credentials-it.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - 'main'
-  pull_request:
+  pull_request_target:
 
 jobs:
   gcloud:

--- a/.github/workflows/deploy-cloudrun-it.yml
+++ b/.github/workflows/deploy-cloudrun-it.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - 'main'
-  pull_request:
+  pull_request_target:
 
 jobs:
   envvars:

--- a/.github/workflows/deploy-cloudrun-traffic-it.yml
+++ b/.github/workflows/deploy-cloudrun-traffic-it.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: 
     - 'main'
-  pull_request:
+  pull_request_target:
 
 jobs:
   source:


### PR DESCRIPTION
For dependabot to have access to secrets, we need to use pull_request_target. The if statement should still prevent forks from accessing secrets.