### PR TITLE
Always update traffic if tag_traffic or revision_traffic is given

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -113,6 +113,7 @@ jobs:
           env_vars_update_strategy: 'overwrite'
           secrets: /api/secrets/my-secret=${{ vars.SECRET_NAME }}:latest
           secrets_update_strategy: 'overwrite'
+          to_revision: 'LATEST=100'
 
       - name: 'Run re-deploy tests'
         run: 'npm run e2e-tests'
@@ -201,6 +202,7 @@ jobs:
         with:
           image: 'gcr.io/cloudrun/hello'
           service: '${{ env.SERVICE_NAME }}'
+          to_revision: 'LATEST=100'
 
       - name: 'Run re-deploy tests'
         run: 'npm run e2e-tests' # Check that config isn't overwritten

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ jobs:
     code](https://cloud.google.com/run/docs/deploying-source-code).
 
 -   <a name="suffix"></a><a href="#user-content-suffix"><code>suffix</code></a>: _(Optional)_ String suffix to append to the revision name. Revision names always start
-    with the service name automatically. For example, specifying 'v1' for a
-    service named 'helloworld', would lead to a revision named
-    'helloworld-v1'.
+    with the service name automatically. For example, specifying `v1` for a
+    service named `helloworld`, would lead to a revision named
+    `helloworld-v1`. This option is only applies to services.
 
 -   <a name="env_vars"></a><a href="#user-content-env_vars"><code>env_vars</code></a>: _(Optional)_ List of environment variables that should be set in the environment.
     These are comma-separated or newline-separated `KEY=VALUE`. Keys or values
@@ -179,7 +179,8 @@ jobs:
 
     Setting this to `true` will skip adding these special labels.
 
--   <a name="tag"></a><a href="#user-content-tag"><code>tag</code></a>: _(Optional)_ Traffic tag to assign to the newly-created revision.
+-   <a name="tag"></a><a href="#user-content-tag"><code>tag</code></a>: _(Optional)_ Traffic tag to assign to the newly-created revision. This option is only
+    applies to services.
 
 -   <a name="timeout"></a><a href="#user-content-timeout"><code>timeout</code></a>: _(Optional)_ Maximum request execution time, specified as a duration like "10m5s" for
     ten minutes and 5 seconds.
@@ -202,11 +203,12 @@ jobs:
 
     Please note, this GitHub Action does not parse or validate the flags. You
     are responsible for making sure the flags are available on the gcloud
-    version and subcommand. When using `tag_traffic` or `revision_traffic`,
-    the subcommand is `gcloud run services update-traffic`. For all other
-    values, the subcommand is `gcloud run deploy`.
+    version and subcommand. The provided flags will be appended to the
+    `deploy` command. When `revision_traffic` or `tag_traffic` are set, the
+    flags will also be appended to the subsequent `update-traffic` command.
 
--   <a name="no_traffic"></a><a href="#user-content-no_traffic"><code>no_traffic</code></a>: _(Optional, default: `false`)_ If true, the newly deployed revision will not receive traffic.
+-   <a name="no_traffic"></a><a href="#user-content-no_traffic"><code>no_traffic</code></a>: _(Optional, default: `false`)_ If true, the newly deployed revision will not receive traffic. This option
+    is only applies to services.
 
 -   <a name="revision_traffic"></a><a href="#user-content-revision_traffic"><code>revision_traffic</code></a>: _(Optional)_ Comma-separated list of revision traffic assignments.
 
@@ -218,14 +220,16 @@ jobs:
         with:
           revision_traffic: 'LATEST=100'
 
-    This is mutually-exclusive with `tag_traffic`.
+    This is mutually-exclusive with `tag_traffic`. This option is only applies
+    to services.
 
 -   <a name="tag_traffic"></a><a href="#user-content-tag_traffic"><code>tag_traffic</code></a>: _(Optional)_ Comma-separated list of tag traffic assignments.
 
         with:
           tag_traffic: 'my-tag=10' # percentage
 
-    This is mutually-exclusive with `revision_traffic`.
+    This is mutually-exclusive with `revision_traffic`. This option is only
+    applies to services.
 
 -   <a name="project_id"></a><a href="#user-content-project_id"><code>project_id</code></a>: _(Optional)_ ID of the Google Cloud project in which to deploy the service.
 

--- a/action.yml
+++ b/action.yml
@@ -61,9 +61,9 @@ inputs:
   suffix:
     description: |-
       String suffix to append to the revision name. Revision names always start
-      with the service name automatically. For example, specifying 'v1' for a
-      service named 'helloworld', would lead to a revision named
-      'helloworld-v1'.
+      with the service name automatically. For example, specifying `v1` for a
+      service named `helloworld`, would lead to a revision named
+      `helloworld-v1`. This option is only applies to services.
     required: false
 
   env_vars:
@@ -186,7 +186,8 @@ inputs:
 
   tag:
     description: |-
-      Traffic tag to assign to the newly-created revision.
+      Traffic tag to assign to the newly-created revision. This option is only
+      applies to services.
     required: false
 
   timeout:
@@ -215,14 +216,15 @@ inputs:
 
       Please note, this GitHub Action does not parse or validate the flags. You
       are responsible for making sure the flags are available on the gcloud
-      version and subcommand. When using `tag_traffic` or `revision_traffic`,
-      the subcommand is `gcloud run services update-traffic`. For all other
-      values, the subcommand is `gcloud run deploy`.
+      version and subcommand. The provided flags will be appended to the
+      `deploy` command. When `revision_traffic` or `tag_traffic` are set, the
+      flags will also be appended to the subsequent `update-traffic` command.
     required: false
 
   no_traffic:
     description: |-
-      If true, the newly deployed revision will not receive traffic.
+      If true, the newly deployed revision will not receive traffic. This option
+      is only applies to services.
     default: 'false'
     required: false
 
@@ -238,7 +240,8 @@ inputs:
           with:
             revision_traffic: 'LATEST=100'
 
-      This is mutually-exclusive with `tag_traffic`.
+      This is mutually-exclusive with `tag_traffic`. This option is only applies
+      to services.
     required: false
 
   tag_traffic:
@@ -248,7 +251,8 @@ inputs:
           with:
             tag_traffic: 'my-tag=10' # percentage
 
-      This is mutually-exclusive with `revision_traffic`.
+      This is mutually-exclusive with `revision_traffic`. This option is only
+      applies to services.
     required: false
 
   project_id:

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -101,7 +101,7 @@ test('#run', { concurrency: true }, async (suite) => {
     });
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['--project', 'my-test-project']);
   });
 
@@ -112,7 +112,7 @@ test('#run', { concurrency: true }, async (suite) => {
     });
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['--region', 'us-central1']);
   });
 
@@ -123,7 +123,7 @@ test('#run', { concurrency: true }, async (suite) => {
     });
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['--region', 'us-central1,us-east1']);
   });
 
@@ -209,7 +209,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const envVars = splitKV(args.at(args.indexOf('--update-env-vars') + 1));
     assert.deepStrictEqual(envVars, { FOO: 'BAR' });
   });
@@ -223,7 +223,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const envVars = splitKV(args.at(args.indexOf('--set-env-vars') + 1));
     assert.deepStrictEqual(envVars, { FOO: 'BAR' });
   });
@@ -236,7 +236,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const envVars = splitKV(args.at(args.indexOf('--update-secrets') + 1));
     assert.deepStrictEqual(envVars, { FOO: 'bar:latest' });
   });
@@ -250,7 +250,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const envVars = splitKV(args.at(args.indexOf('--set-secrets') + 1));
     assert.deepStrictEqual(envVars, { FOO: 'bar:latest' });
   });
@@ -271,7 +271,7 @@ test('#run', { concurrency: true }, async (suite) => {
       'foo': 'bar',
       'zip': 'zap',
     };
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const labels = splitKV(args.at(args.indexOf('--update-labels') + 1));
     assert.deepStrictEqual(labels, expectedLabels);
   });
@@ -289,7 +289,7 @@ test('#run', { concurrency: true }, async (suite) => {
       foo: 'bar',
       zip: 'zap',
     };
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const labels = splitKV(args.at(args.indexOf('--update-labels') + 1));
     assert.deepStrictEqual(labels, expectedLabels);
   });
@@ -307,7 +307,7 @@ test('#run', { concurrency: true }, async (suite) => {
       'managed-by': 'github-actions',
       'commit-sha': 'custom-value',
     };
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     const labels = splitKV(args.at(args.indexOf('--update-labels') + 1));
     assert.deepStrictEqual(labels, expectedLabels);
   });
@@ -321,7 +321,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['--source', 'example-app']);
   });
 
@@ -333,7 +333,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['services', 'replace']);
   });
 
@@ -345,7 +345,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['jobs', 'replace']);
   });
 
@@ -357,7 +357,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['--timeout', '55m12s']);
   });
 
@@ -369,20 +369,23 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['--tag', 'test']);
   });
 
   await suite.test('sets tag traffic if given', async (t) => {
     const mocks = defaultMocks(t.mock, {
       service: 'my-test-service',
-      tag: 'test',
+      tag_traffic: 'TEST=100',
     });
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
-    assertMembers(args, ['--tag', 'test']);
+    const deployArgs = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
+    assertMembers(deployArgs, ['run', 'deploy', 'my-test-service']);
+
+    const updateTrafficArgs = mocks.getExecOutput.mock.calls?.at(1)?.arguments?.at(1);
+    assertMembers(updateTrafficArgs, ['--to-tags', 'TEST=100']);
   });
 
   await suite.test('fails if tag traffic and revision traffic are provided', async (t) => {
@@ -412,6 +415,21 @@ test('#run', { concurrency: true }, async (suite) => {
       },
       { message: /no service name set/ },
     );
+  });
+
+  await suite.test('sets revision traffic if given', async (t) => {
+    const mocks = defaultMocks(t.mock, {
+      service: 'my-test-service',
+      revision_traffic: 'TEST=100',
+    });
+
+    await run();
+
+    const deployArgs = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
+    assertMembers(deployArgs, ['run', 'deploy', 'my-test-service']);
+
+    const updateTrafficArgs = mocks.getExecOutput.mock.calls?.at(1)?.arguments?.at(1);
+    assertMembers(updateTrafficArgs, ['--to-revisions', 'TEST=100']);
   });
 
   await suite.test('fails if service is not provided with revision traffic', async (t) => {
@@ -449,7 +467,7 @@ test('#run', { concurrency: true }, async (suite) => {
 
     await run();
 
-    const args = mocks.getExecOutput.mock.calls?.at(0).arguments?.at(1);
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['run', 'jobs', 'deploy', 'my-test-job']);
   });
 });


### PR DESCRIPTION
Closes #533

This could potentially be a breaking change for anyone using a step that had an `image` or `source` with a `tag_traffic` or `revision_traffic`. Previously this would not re-deploy, but now it does.