### PR TITLE
Expose created revision name as an output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -308,6 +308,9 @@ outputs:
   url:
     description: |-
       The URL of the Cloud Run service.
+  revision:
+    description: |-
+      The name of the latest created revision from the deployment.
 
 branding:
   icon: 'chevrons-right'

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,6 +67,7 @@ const isDebug =
  */
 export interface DeployCloudRunOutputs {
   url?: string | null | undefined; // Type required to match run_v1.Schema$Service.status.url
+  revision?: string | null | undefined; // Latest created revision name from the deployment
 }
 
 /**

--- a/src/output-parser.ts
+++ b/src/output-parser.ts
@@ -104,6 +104,7 @@ export function parseDeployResponse(
     // Set outputs
     const outputs: DeployCloudRunOutputs = {
       url: outputJSON?.status?.url,
+      revision: outputJSON?.status?.latestCreatedRevisionName,
     };
 
     // Maintain current logic to use tag url if provided


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
Closes #555.

Adds an output attribute to the action, `revision`, which is the `latestCreatedRevisionName`. 

This will allow subsequent action steps to allocate traffic/run any checks on _the new revision specifically_. 
