### PR TITLE
Update error messages to better handle long commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -317,7 +317,7 @@ export async function run(): Promise<void> {
       const errMsg =
         deployCmdExec.stderr ||
         `command exited ${deployCmdExec.exitCode}, but stderr had no output`;
-      throw new Error(`failed to execute gcloud command \`${commandString}\`: ${errMsg}`);
+      throw new Error(`failed to deploy: ${errMsg}, full command: \`${commandString}\``);
     }
     setActionOutputs(parseDeployResponse(deployCmdExec.stdout, { tag: tag }));
 
@@ -328,7 +328,7 @@ export async function run(): Promise<void> {
         const errMsg =
           updateTrafficExec.stderr ||
           `command exited ${updateTrafficExec.exitCode}, but stderr had no output`;
-        throw new Error(`failed to execute gcloud command \`${commandString}\`: ${errMsg}`);
+        throw new Error(`failed to update traffic: ${errMsg}, full command: \`${commandString}\``);
       }
       setActionOutputs(parseUpdateTrafficResponse(updateTrafficExec.stdout));
     }


### PR DESCRIPTION
When running this action with large number of environment variables the resulting gcloud command gets very long, and if it fails the error message visible in github actions output is cut off before it gets to the actually useful bit with the error message, making it impossible to tell what went wrong.

This adjusts the message the put the command at the end. It's likely less interesting since it's constructed from inputs the user provides anyway.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
