### PR TITLE
feat: add support for --wait flag in jobs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -229,6 +229,13 @@ inputs:
     default: 'false'
     required: false
 
+  wait:
+    description: |-
+      If true, the action will wait for the job to complete before exiting. This
+      option only applies to jobs.
+    default: 'true'
+    required: false
+
   revision_traffic:
     description: |-
       Comma-separated list of revision traffic assignments.

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,7 @@ export async function run(): Promise<void> {
     const tag = getInput('tag');
     const timeout = getInput('timeout');
     const noTraffic = (getInput('no_traffic') || '').toLowerCase() === 'true';
+    const wait = parseBoolean(getInput('wait'));
     const revTraffic = getInput('revision_traffic');
     const tagTraffic = getInput('tag_traffic');
     const labels = parseKVString(getInput('labels'));
@@ -195,6 +196,10 @@ export async function run(): Promise<void> {
       // Set optional flags from inputs
       setEnvVarsFlags(deployCmd, envVars, envVarsFile, envVarsUpdateStrategy);
       setSecretsFlags(deployCmd, secrets, secretsUpdateStrategy);
+
+      if (wait) {
+        deployCmd.push('--wait');
+      }
 
       // There is no --update-secrets flag on jobs, but there will be in the
       // future. At that point, we can remove this.

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -520,6 +520,30 @@ test('#run', { concurrency: true }, async (suite) => {
     const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
     assertMembers(args, ['run', 'jobs', 'deploy', 'my-test-job']);
   });
+
+  await suite.test('deploys a job with --wait', async (t) => {
+    const mocks = defaultMocks(t.mock, {
+      job: 'my-test-job',
+      wait: 'true',
+    });
+
+    await run();
+
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
+    assert.ok(args?.includes('--wait'));
+  });
+
+  await suite.test('deploys a job without --wait', async (t) => {
+    const mocks = defaultMocks(t.mock, {
+      job: 'my-test-job',
+      wait: 'false',
+    });
+
+    await run();
+
+    const args = mocks.getExecOutput.mock.calls?.at(0)?.arguments?.at(1);
+    assert.ok(!args.includes('--wait'));
+  });
 });
 
 const splitKV = (s: string): Record<string, string> => {


### PR DESCRIPTION
Per documentation of `gcloud run jobs deploy` - https://cloud.google.com/sdk/gcloud/reference/run/jobs/deploy#--wait

There is available flag `--wait` there are use cases where you may want to use that. i.e. sometimes you want job to do synchronization or do database migrations before you deploy the cloud run service. With `--wait` flag you can wait in your Github Actions until action would be successful. 