### PR TITLE
Print error messages before command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -322,7 +322,7 @@ export async function run(): Promise<void> {
       const errMsg =
         deployCmdExec.stderr ||
         `command exited ${deployCmdExec.exitCode}, but stderr had no output`;
-      throw new Error(`failed to execute gcloud command \`${commandString}\`: ${errMsg}`);
+      throw new Error(`failed to deploy: ${errMsg}, full command:\n\t${commandString}`);
     }
     setActionOutputs(parseDeployResponse(deployCmdExec.stdout, { tag: tag }));
 
@@ -333,7 +333,7 @@ export async function run(): Promise<void> {
         const errMsg =
           updateTrafficExec.stderr ||
           `command exited ${updateTrafficExec.exitCode}, but stderr had no output`;
-        throw new Error(`failed to execute gcloud command \`${commandString}\`: ${errMsg}`);
+        throw new Error(`failed to update traffic: ${errMsg}, full command:\n\t${commandString}`);
       }
       setActionOutputs(parseUpdateTrafficResponse(updateTrafficExec.stdout));
     }


### PR DESCRIPTION
This prevents long commands from hiding the error message

Fixes #569 