### PR TITLE
Make `wait` option default to `false`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -220,9 +220,9 @@ inputs:
 
   wait:
     description: |-
-      If true, the action will wait for the job to complete before exiting. This
+      If true, the action will execute and wait for the job to complete before exiting. This
       option only applies to jobs.
-    default: 'true'
+    default: 'false'
     required: false
 
   revision_traffic:


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->

When the `wait` option was introduced, it was set to `true` as default. The way this flag works in the gcloud CLI is that it will execute the job and then wait for it to succeed. This is a major change in the action's behavior, and should be opt-in.

Fixes #578
