### PR TITLE
Make "wait" default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ jobs:
 -   <a name="__input_no_traffic"></a><a href="#user-content-__input_no_traffic"><code>no_traffic</code></a>: _(Optional, default: `false`)_ If true, the newly deployed revision will not receive traffic. This option
     only applies to services.
 
--   <a name="__input_wait"></a><a href="#user-content-__input_wait"><code>wait</code></a>: _(Optional, default: `true`)_ If true, the action will wait for the job to complete before exiting. This
-    option only applies to jobs.
+-   <a name="__input_wait"></a><a href="#user-content-__input_wait"><code>wait</code></a>: _(Optional, default: `false`)_ If true, the action will execute and wait for the job to complete before
+    exiting. This option only applies to jobs.
 
 -   <a name="__input_revision_traffic"></a><a href="#user-content-__input_revision_traffic"><code>revision_traffic</code></a>: _(Optional)_ Comma-separated list of revision traffic assignments.
 

--- a/action.yml
+++ b/action.yml
@@ -220,9 +220,9 @@ inputs:
 
   wait:
     description: |-
-      If true, the action will wait for the job to complete before exiting. This
-      option only applies to jobs.
-    default: 'true'
+      If true, the action will execute and wait for the job to complete before
+      exiting. This option only applies to jobs.
+    default: 'false'
     required: false
 
   revision_traffic:


### PR DESCRIPTION
This was an unintentional breaking change, but we didn't catch it because GitHub changed how floating tags work.

- Closes https://github.com/google-github-actions/deploy-cloudrun/issues/578
- Closes https://github.com/google-github-actions/deploy-cloudrun/pull/579